### PR TITLE
Remove autologic for assigning head of household

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -126,18 +126,20 @@ class PatientsController < ApplicationController
       patient.monitored_address_zip = patient.address_zip
     end
     helpers.normalize_state_names(patient)
+
+    # NOTE: Remove head of household logic for now
     # Set the responder for this patient, this will link patients that have duplicate primary contact info
-    patient.responder = if params.permit(:responder_id)[:responder_id]
-                          current_user.get_patient(params.permit(:responder_id)[:responder_id])
-                        elsif ['SMS Texted Weblink', 'Telephone call', 'SMS Text-message'].include? patient[:preferred_contact_method]
-                          if current_user.viewable_patients.responder_for_number(patient[:primary_telephone])&.exists?
-                            current_user.viewable_patients.responder_for_number(patient[:primary_telephone]).first
-                          end
-                        elsif patient[:preferred_contact_method] == 'E-mailed Web Link'
-                          if current_user.viewable_patients.responder_for_email(patient[:email])&.exists?
-                            current_user.viewable_patients.responder_for_email(patient[:email]).first
-                          end
-                        end
+    # patient.responder = if params.permit(:responder_id)[:responder_id]
+    #                       current_user.get_patient(params.permit(:responder_id)[:responder_id])
+    #                     elsif ['SMS Texted Weblink', 'Telephone call', 'SMS Text-message'].include? patient[:preferred_contact_method]
+    #                       if current_user.viewable_patients.responder_for_number(patient[:primary_telephone])&.exists?
+    #                         current_user.viewable_patients.responder_for_number(patient[:primary_telephone]).first
+    #                       end
+    #                     elsif patient[:preferred_contact_method] == 'E-mailed Web Link'
+    #                       if current_user.viewable_patients.responder_for_email(patient[:email])&.exists?
+    #                         current_user.viewable_patients.responder_for_email(patient[:email]).first
+    #                       end
+    #                     end
 
     # Default responder to self if no responder condition met
     patient.responder = patient if patient.responder.nil?


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-###

Write out a concise summary of this pull request and what it addresses.

# (Feature) Demo/Screenshots
Insert demo video or photos for a new or updated feature or capability.

# (Bugfix) How to Replicate
Create two patients with the same primary contact. 

# (Bugfix) Solution
Commented out the logic inside the patient controller which automatically formed households if the primary form of contact is the same.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
