### PR TITLE
SAVAMC-30 Add in Other Race as an option to patient

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -536,6 +536,7 @@ class PatientsController < ApplicationController
       :american_indian_or_alaska_native,
       :asian,
       :native_hawaiian_or_other_pacific_islander,
+      :other_race,
       :ethnicity,
       :primary_language,
       :secondary_language,

--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -69,6 +69,7 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       american_indian_or_alaska_native: american_indian_or_alaska_native || false,
       asian: asian || false,
       native_hawaiian_or_other_pacific_islander: native_hawaiian_or_other_pacific_islander || false,
+      other_race: other_race || false, 
       ethnicity: ethnicity || '',
       primary_language: primary_language || '',
       secondary_language: secondary_language || '',

--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -106,6 +106,7 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
     american_indian_or_alaska_native: { label: 'American Indian or Alaska Native', checks: [:bool] },
     asian: { label: 'Asian', checks: [:bool] },
     native_hawaiian_or_other_pacific_islander: { label: 'Native Hawaiian or Other Pacific Islander', checks: [:bool] },
+    other_race: { label: 'Other', checks: [:bool]},
     ethnicity: { label: 'Ethnicity', checks: [:enum] },
     interpretation_required: { label: 'Interpretation Required?', checks: [:bool] },
     address_state: { label: 'State', checks: %i[required state] },

--- a/app/javascript/components/enrollment/steps/Identification.js
+++ b/app/javascript/components/enrollment/steps/Identification.js
@@ -390,6 +390,14 @@ class Identification extends React.Component {
                     checked={this.state.current.patient.native_hawaiian_or_other_pacific_islander}
                     onChange={this.handleChange}
                   />
+                  <Form.Check
+                    className="pt-2"
+                    type="switch"
+                    id="other_race"
+                    label="OTHER"
+                    checked={this.state.current.patient.other_race}
+                    onChange={this.handleChange}
+                  />
                 </Form.Group>
                 <Form.Group as={Col} md="1"></Form.Group>
                 <Form.Group as={Col} md="8" controlId="ethnicity">
@@ -569,6 +577,7 @@ const schema = yup.object().shape({
   american_indian_or_alaska_native: yup.boolean().nullable(),
   asian: yup.boolean().nullable(),
   native_hawaiian_or_other_pacific_islander: yup.boolean().nullable(),
+  other_race: yup.boolean().nullable(),
   ethnicity: yup
     .string()
     .max(200, 'Max length exceeded, please limit to 200 characters.')

--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -97,7 +97,7 @@ class Patient extends React.Component {
                   this.props.details.black_or_african_american ? ' Black or African American' : ''
                 }${this.props.details.asian ? ' Asian' : ''}${this.props.details.american_indian_or_alaska_native ? ' American Indian or Alaska Native' : ''}${
                   this.props.details.native_hawaiian_or_other_pacific_islander ? ' Native Hawaiian or Other Pacific Islander' : ''
-                }`}</span>
+                }${this.props.details.other_race ? ' Other' : ''}`}</span>
                 <br />
                 <span className="font-weight-normal">Ethnicity:</span>{' '}
                 <span className="font-weight-light">{`${this.props.details.ethnicity ? this.props.details.ethnicity : ''}`}</span>

--- a/app/jobs/purge_job.rb
+++ b/app/jobs/purge_job.rb
@@ -51,7 +51,7 @@ class PurgeJob < ApplicationJob
        laboratory_personnel was_in_health_care_facility_with_known_cases
        healthcare_personnel crew_on_passenger_or_cargo_flight white
        black_or_african_american american_indian_or_alaska_native asian
-       native_hawaiian_or_other_pacific_islander ethnicity purged
+       native_hawaiian_or_other_pacific_islander other_race ethnicity purged
        continuous_exposure]
   end
 end

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -9,7 +9,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
                       'Transferred From', 'Transferred To', 'Expected Purge Date', 'Symptom Onset', 'Extended Isolation'].freeze
 
   COMPREHENSIVE_HEADERS = ['First Name', 'Middle Name', 'Last Name', 'Date of Birth', 'Sex at Birth', 'White', 'Black or African American',
-                           'American Indian or Alaska Native', 'Asian', 'Native Hawaiian or Other Pacific Islander', 'Ethnicity', 'Primary Language',
+                           'American Indian or Alaska Native', 'Asian', 'Native Hawaiian or Other Pacific Islander', 'Other Race', 'Ethnicity', 'Primary Language',
                            'Secondary Language', 'Interpretation Required?', 'Nationality', 'Identifier (STATE/LOCAL)', 'Identifier (CDC)',
                            'Identifier (NNDSS)', 'Address Line 1', 'Address City', 'Address State', 'Address Line 2', 'Address Zip', 'Address County',
                            'Foreign Address Line 1', 'Foreign Address City', 'Foreign Address Country', 'Foreign Address Line 2', 'Foreign Address Zip',
@@ -52,7 +52,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
                    'Exposure Assessment', 'Contact Made?', 'Monitoring needed?', 'Notes'].freeze
 
   COMPREHENSIVE_FIELDS = [:first_name, :middle_name, :last_name, :date_of_birth, :sex, :white, :black_or_african_american, :american_indian_or_alaska_native,
-                          :asian, :native_hawaiian_or_other_pacific_islander, :ethnicity, :primary_language, :secondary_language, :interpretation_required,
+                          :asian, :native_hawaiian_or_other_pacific_islander, :other_race, :ethnicity, :primary_language, :secondary_language, :interpretation_required,
                           :nationality, :user_defined_id_statelocal, :user_defined_id_cdc, :user_defined_id_nndss, :address_line_1, :address_city,
                           :address_state, :address_line_2, :address_zip, :address_county, :foreign_address_line_1, :foreign_address_city,
                           :foreign_address_country, :foreign_address_line_2, :foreign_address_zip, :foreign_address_line_3, :foreign_address_state,
@@ -470,6 +470,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
         american_indian_or_alaska_native: patient[:american_indian_or_alaska_native] || false,
         asian: patient[:asian] || false,
         native_hawaiian_or_other_pacific_islander: patient[:native_hawaiian_or_other_pacific_islander] || false,
+        other_race: patient[:other_race] || false, 
         ethnicity: patient[:ethnicity] || '',
         primary_language: patient[:primary_language] || '',
         secondary_language: patient[:secondary_language] || '',

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -919,6 +919,7 @@ class Patient < ApplicationRecord
       american_indian_or_alaska_native: PatientHelper.race_code?(patient, '1002-5'),
       asian: PatientHelper.race_code?(patient, '2028-9'),
       native_hawaiian_or_other_pacific_islander: PatientHelper.race_code?(patient, '2076-8'),
+      other_race: patient&.other_race.nil? ? false : patient.other_race,
       ethnicity: PatientHelper.ethnicity(patient),
       sex: PatientHelper.birthsex(patient),
       preferred_contact_method: PatientHelper.from_preferred_contact_method_extension(patient),

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,7 +6,7 @@
 # Patient filters
 Rails.application.config.filter_parameters += %i[password first_name middle_name last_name date_of_birth age sex white
                                                  black_or_african_american american_indian_or_alaska_native  asian
-                                                 native_hawaiian_or_other_pacific_islander ethnicity nationality
+                                                 native_hawaiian_or_other_pacific_islander other_race ethnicity nationality
                                                  address_line_1 foreign_address_line_1 address_city address_state
                                                  address_line_2 address_zip address_county monitored_address_line_1
                                                  monitored_address_city monitored_address_state monitored_address_line_2

--- a/db/migrate/20201201172200_add_other_race_to_patients.rb
+++ b/db/migrate/20201201172200_add_other_race_to_patients.rb
@@ -1,0 +1,5 @@
+class AddOtherRaceToPatients < ActiveRecord::Migration[6.0]
+  def change
+    add_column :patients, :other_race, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_24_022805) do
+ActiveRecord::Schema.define(version: 2020_12_01_172200) do
 
   create_table "analytics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "jurisdiction_id"
@@ -372,6 +372,7 @@ ActiveRecord::Schema.define(version: 2020_11_24_022805) do
     t.date "extended_isolation"
     t.boolean "head_of_household"
     t.date "severe_symptom_onset"
+    t.boolean "other_race"
     t.index ["assigned_user"], name: "index_patients_on_assigned_user"
     t.index ["creator_id"], name: "index_patients_on_creator_id"
     t.index ["date_of_birth"], name: "index_patients_on_date_of_birth"

--- a/test/jobs/purge_job_test.rb
+++ b/test/jobs/purge_job_test.rb
@@ -87,7 +87,7 @@ class PurgeJobTest < ActiveSupport::TestCase
                                last_assessment_reminder_sent: 1.month.ago, user_defined_id_statelocal: '1', user_defined_id_cdc: '1',
                                user_defined_id_nndss: '1', first_name: 'a', last_name: 'a', date_of_birth: 1.year.ago, age: 1, sex: 'Unknown',
                                white: false, black_or_african_american: false, american_indian_or_alaska_native: false, asian: false,
-                               native_hawaiian_or_other_pacific_islander: false, ethnicity: 'Hispanic or Latino', primary_language: 'a',
+                               native_hawaiian_or_other_pacific_islander: false, other_race: false, ethnicity: 'Hispanic or Latino', primary_language: 'a',
                                secondary_language: 'a', interpretation_required: false, nationality: 'a', address_line_1: 'a',
                                foreign_address_line_1: 'a', address_city: 'a', address_state: 'Texas', address_line_2: 'a', address_zip: 'a',
                                address_county: 'a', monitored_address_line_1: 'a', monitored_address_city: 'a', monitored_address_state: 'Texas',

--- a/test/system/roles/enroller/enrollment/steps.rb
+++ b/test/system/roles/enroller/enrollment/steps.rb
@@ -15,6 +15,7 @@ class EnrollmentFormSteps < ApplicationSystemTestCase
         { id: 'black_or_african_american', type: 'race', required: false, info_page: 'Black or African American', label: 'BLACK OR AFRICAN AMERICAN' },
         { id: 'american_indian_or_alaska_native', type: 'race', required: false, info_page: 'American Indian or Alaska Native', label: 'AMERICAN INDIAN OR ALASKA NATIVE' },
         { id: 'asian', type: 'race', required: false, info_page: 'Asian', label: 'ASIAN' },
+        { id: 'other_race', type: 'race', required: false, info_page: 'Other Race', label: 'OTHER' },
         { id: 'native_hawaiian_or_other_pacific_islander', type: 'race', required: false, info_page: 'Native Hawaiian or Other Pacific Islander', label: 'NATIVE HAWAIIAN OR OTHER PACIFIC ISLANDER' },
         { id: 'ethnicity', type: 'select', required: false, info_page: true },
         { id: 'primary_language', type: 'language', required: false, info_page: true },

--- a/test/system/roles/public_health/dashboard/import_verifier.rb
+++ b/test/system/roles/public_health/dashboard/import_verifier.rb
@@ -10,7 +10,7 @@ class PublicHealthMonitoringImportVerifier < ApplicationSystemTestCase
   @@system_test_utils = SystemTestUtils.new(nil)
 
   TELEPHONE_FIELDS = %i[primary_telephone secondary_telephone].freeze
-  BOOL_FIELDS = %i[white black_or_african_american american_indian_or_alaska_native asian native_hawaiian_or_other_pacific_islander interpretation_required
+  BOOL_FIELDS = %i[white black_or_african_american american_indian_or_alaska_native asian native_hawaiian_or_other_pacific_islander other_race interpretation_required
                    contact_of_known_case travel_to_affected_country_or_area was_in_health_care_facility_with_known_cases laboratory_personnel
                    healthcare_personnel crew_on_passenger_or_cargo_flight member_of_a_common_exposure_cohort].freeze
   STATE_FIELDS = %i[address_state foreign_monitored_address_state additional_planned_travel_destination_state].freeze


### PR DESCRIPTION
# Description
Jira Ticket: SAVAMC-30

Add "Other" as an option for Race for Patient enrollment. 

You will need to run `rails db:migrate` to add the `other_race` column to the Patient model. 

# (Feature) Demo/Screenshots
Insert demo video or photos for a new or updated feature or capability.

# (Bugfix) How to Replicate
Insert steps for how to replicate the bug this PR addresses.

# (Bugfix) Solution
Insert description for the solution this PR implements to address the bug.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
