### PR TITLE
SAVAMC2-68 SAVAMC2-77 Change ID Headers and Show VACCS Id

### DIFF
--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -81,6 +81,9 @@ class Patient extends React.Component {
                 <br />
                 <span className="font-weight-normal">NNDSS ID:</span>{' '}
                 <span className="font-weight-light">{`${this.props.details.user_defined_id_nndss ? this.props.details.user_defined_id_nndss : ''}`}</span>
+                <br />
+                <span className="font-weight-normal">VACCS ID:</span> <span className="font-weight-light">{`${this.props.details.id}`}</span>
+                <br />
               </Col>
               <Col className="text-truncate">
                 <span className="font-weight-normal">Birth Sex:</span>{' '}

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -70,7 +70,7 @@
     <table class="assessment_table table table-sm table-striped table-bordered table-hover table-smaller-font">
       <thead>
         <tr>
-          <th class="DataTable-table-header">ID</th>
+          <th class="DataTable-table-header">Report ID</th>
           <% unless @patient.isolation %>
           <th class="DataTable-table-header dt-a-w-50">Needs Review <%= react_component('util/InfoTooltip', { tooltipTextKey: 'exposureNeedsReviewColumn', location: 'right' }, { style: 'display:inline' }) %></th>
           <% end %>
@@ -175,7 +175,7 @@
     <table class="dosage_table table table-sm table-striped table-bordered table-hover table-smaller-font" style="width:100%">
       <thead>
         <tr>
-          <th class="DataTable-table-header">ID</th>
+          <th class="DataTable-table-header">Vaccine Dose ID</th>
           <th class="DataTable-table-header">Dose Number</th>
           <th class="DataTable-table-header">CVX</th>
           <th class="DataTable-table-header">Manufacturer</th>


### PR DESCRIPTION
# Description
Jira Ticket: SAVAMC2-68 and SAVAMC2-77

On the Patient page:
* SAVAMC2-68: Changed the headers in the Reports table and Vaccine Dosage table to be more explicit
* SAVAMC2-77: Added VACCS ID (system patient id) to be displayed

# (Feature) Demo/Screenshots
![Screen Shot 2020-12-02 at 11 00 17 AM](https://user-images.githubusercontent.com/6525651/100902313-c599e980-3492-11eb-949a-f9b5ceab1881.png)
![Screen Shot 2020-12-02 at 11 38 08 AM](https://user-images.githubusercontent.com/6525651/100902436-e06c5e00-3492-11eb-8776-38c98ac6fda6.png)



# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
