### PR TITLE
SAVAMC2-74 Remove Export Labs from VACCS output

### DIFF
--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -101,7 +101,7 @@ class ExportJob < ApplicationJob
                             export_type)
         lookups << get_file(user_id,
                             excel_export_dosages(group),
-                            build_filename('Sara-Alert-Purge-Eligible-Export-Dosages', file_index, file_extension),
+                            build_filename(export_app_name + '-Purge-Eligible-Export-Dosages', file_index, file_extension),
                             export_type)
       end
     end

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -65,10 +65,10 @@ class ExportJob < ApplicationJob
                             excel_export_assessments(group),
                             build_filename(export_app_name + '-Full-Export-Assessments', file_index, file_extension),
                             export_type)
-        lookups << get_file(user_id,
-                            excel_export_lab_results(group),
-                            build_filename(export_app_name + '-Full-Export-Lab-Results', file_index, file_extension),
-                            export_type)
+        # lookups << get_file(user_id,
+        #                     excel_export_lab_results(group),
+        #                     build_filename(export_app_name + '-Full-Export-Lab-Results', file_index, file_extension),
+        #                     export_type)
         lookups << get_file(user_id,
                             excel_export_histories(group),
                             build_filename(export_app_name + '-Full-Export-Histories', file_index, file_extension),
@@ -91,10 +91,10 @@ class ExportJob < ApplicationJob
                             excel_export_assessments(group),
                             build_filename(export_app_name + '-Purge-Eligible-Export-Assessments', file_index, file_extension),
                             export_type)
-        lookups << get_file(user_id,
-                            excel_export_lab_results(group),
-                            build_filename(export_app_name + '-Purge-Eligible-Export-Lab-Results', file_index, file_extension),
-                            export_type)
+        # lookups << get_file(user_id,
+        #                     excel_export_lab_results(group),
+        #                     build_filename(export_app_name + '-Purge-Eligible-Export-Lab-Results', file_index, file_extension),
+        #                     export_type)
         lookups << get_file(user_id,
                             excel_export_histories(group),
                             build_filename(export_app_name + '-Purge-Eligible-Export-Histories', file_index, file_extension),

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -158,14 +158,14 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
           end
         end
       end
-      p.workbook.add_worksheet(name: 'Lab Results') do |sheet|
-        labs = Laboratory.where(patient_id: patients.pluck(:id))
-        lab_headers = ['Patient ID', 'Lab Type', 'Specimen Collection Date', 'Report Date', 'Result Date', 'Created At', 'Updated At']
-        sheet.add_row lab_headers
-        labs.find_each(batch_size: 500) do |lab|
-          sheet.add_row lab.details.values, { types: Array.new(lab_headers.length, :string) }
-        end
-      end
+      # p.workbook.add_worksheet(name: 'Lab Results') do |sheet|
+      #   labs = Laboratory.where(patient_id: patients.pluck(:id))
+      #   lab_headers = ['Patient ID', 'Lab Type', 'Specimen Collection Date', 'Report Date', 'Result Date', 'Created At', 'Updated At']
+      #   sheet.add_row lab_headers
+      #   labs.find_each(batch_size: 500) do |lab|
+      #     sheet.add_row lab.details.values, { types: Array.new(lab_headers.length, :string) }
+      #   end
+      # end
       p.workbook.add_worksheet(name: 'Edit Histories') do |sheet|
         histories = History.where(patient_id: patients.pluck(:id))
         history_headers = ['Patient ID', 'Comment', 'Created By', 'History Type', 'Created At', 'Updated At']


### PR DESCRIPTION
# Description
Jira Ticket: SAVAMC2-74

* Change the file export name for Dosages
* Remove the Lab sheet from Patient export.

NOTE: After discussion, we're just removing the sheets for now. References to Labs in other instances, as well as wrong naming schemes for workflows, are to be addressed in another ticket. 

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

You should be able to use the export option on the UI and an email should appear in your browser. If not, the blob can be found in the `downloads` table. 
