### PR TITLE
SAVAMC2-87 SAVAMC2-120 Update Patient Tables

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -286,12 +286,12 @@ class PublicHealthController < ApplicationController
       return %i[jurisdiction assigned_user extended_isolation symptom_onset monitoring_plan latest_report report_eligibility]
     end
 
-    return %i[jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report status report_eligibility dose1_date dose2_date dose2_app] if tab == :all
+    return %i[jurisdiction end_of_monitoring latest_report status report_eligibility dose1_date dose2_date dose2_app] if tab == :all
     return %i[jurisdiction assigned_user end_of_monitoring risk_level public_health_action latest_report report_eligibility] if tab == :pui
     return %i[transferred_from end_of_monitoring risk_level monitoring_plan transferred_at] if tab == :transferred_in
     return %i[transferred_to end_of_monitoring risk_level monitoring_plan transferred_at] if tab == :transferred_out
 
-    %i[jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report report_eligibility dose1_date dose2_date dose2_app]
+    %i[jurisdiction end_of_monitoring latest_report report_eligibility dose1_date dose2_date dose2_app]
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -8,11 +8,11 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
     return :closed unless monitoring
 
     unless isolation
-      return :exposure_followup unless severe_symptom_onset.nil?
+      return :exposure_follow_up unless severe_symptom_onset.nil?
       return :exposure_under_investigation if public_health_action != 'None'
       return :exposure_symptomatic unless symptom_onset.nil?
-      return :exposure_asymptomatic if (!latest_assessment_at.nil? && latest_assessment_at >= ADMIN_OPTIONS['reporting_period_minutes'].minutes.ago) ||
-                                       (!created_at.nil? && created_at >= ADMIN_OPTIONS['reporting_period_minutes'].minutes.ago)
+      return :exposure_reviewed if (!latest_assessment_at.nil? && latest_assessment_at >= ADMIN_OPTIONS['reporting_period_minutes'].minutes.ago) ||
+      (!created_at.nil? && created_at >= ADMIN_OPTIONS['reporting_period_minutes'].minutes.ago)
 
       return :exposure_non_reporting
     end

--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -51,7 +51,11 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       transferred_from: latest_transfer&.from_path || '',
       transferred_to: latest_transfer&.to_path || '',
       expected_purge_date: updated_at.nil? ? '' : ((updated_at + ADMIN_OPTIONS['purgeable_after'].minutes)&.rfc2822 || ''),
-      extended_isolation: extended_isolation || ''
+      extended_isolation: extended_isolation || '',
+      dose1_date: latest_dose1&.date_given|| '',
+      dose2_date: latest_dosage&.dose_number == 2 ? latest_dosage.date_given : '',
+      dose2_app: '' # Blank for now, until we know how this is defined
+
     }
   end
 

--- a/app/javascript/components/dosage/Dosage.js
+++ b/app/javascript/components/dosage/Dosage.js
@@ -59,6 +59,7 @@ class Dosage extends React.Component {
   }
 
   validate = () => {
+    console.log(this.state);
     const fields = [
       'cvx',
       'manufacturer',
@@ -74,12 +75,14 @@ class Dosage extends React.Component {
       'facility_type',
       'facility_address',
     ];
-    let check = Object.keys(this.state).filter(k => fields.includes(k) && (this.state[`${k}`] == null || this.state[`${k}`].trim() == ''));
+
+    let check = Object.keys(this.state).filter(k => fields.includes(k) && (this.state[`${k}`] == null || String(this.state[`${k}`]).trim() == ''));
     this.setState({ dosageInvalid: check.length > 0 });
   };
 
   handleChange(event) {
     this.setState({ [event.target.id]: event.target.value }, () => {
+      console.log(this.state);
       if (this.state.manufacturer == 'Pfizer') {
         this.setState({ cvx: '208' }, this.validate());
       }

--- a/app/javascript/components/dosage/Dosage.js
+++ b/app/javascript/components/dosage/Dosage.js
@@ -59,7 +59,6 @@ class Dosage extends React.Component {
   }
 
   validate = () => {
-    console.log(this.state);
     const fields = [
       'cvx',
       'manufacturer',
@@ -82,7 +81,6 @@ class Dosage extends React.Component {
 
   handleChange(event) {
     this.setState({ [event.target.id]: event.target.value }, () => {
-      console.log(this.state);
       if (this.state.manufacturer == 'Pfizer') {
         this.setState({ cvx: '208' }, this.validate());
       }

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -37,27 +37,18 @@ class PatientsTable extends React.Component {
     this.advancedFilterUpdate = this.advancedFilterUpdate.bind(this);
     this.state = {
       table: {
+        // Monitoree, Dose 1 Administration Date, Dose 2 appointment date, Dose 2 Administration date, Jurisdiction, Date of Birth, End of Monitoring, Latest Report, Status
         colData: [
           { field: 'name', label: 'Monitoree', isSortable: true, tooltip: null, filter: this.linkPatient },
+          { field: 'dose1_date', label: 'Dose 1 Administration Date', isSortable: true, tooltip: null, filter: this.formatDate },
+          { field: 'dose2_app', label: 'Dose 2 Appointment Date', isSortable: true, tooltip: null, filter: this.formatDate },
+          { field: 'dose2_date', label: 'Dose 2 Administration Date', isSortable: true, tooltip: null, filter: this.formatDate },
           { field: 'jurisdiction', label: 'Jurisdiction', isSortable: true, tooltip: null },
-          { field: 'transferred_from', label: 'From Jurisdiction', isSortable: true, tooltip: null },
-          { field: 'transferred_to', label: 'To Jurisdiction', isSortable: true, tooltip: null },
-          { field: 'assigned_user', label: 'Assigned User', isSortable: true, tooltip: null },
-          { field: 'state_local_id', label: 'State/Local ID', isSortable: true, tooltip: null },
           { field: 'dob', label: 'Date of Birth', isSortable: true, tooltip: null, filter: this.formatDate },
-          { field: 'end_of_monitoring', label: 'End of Monitoring', isSortable: true, tooltip: null, filter: this.formatEndOfMonitoring },
-          { field: 'extended_isolation', label: 'Extended Isolation To', isSortable: true, tooltip: 'extendedIsolation', filter: this.formatDate },
-          { field: 'symptom_onset', label: 'Symptom Onset', isSortable: true, tooltip: null, filter: this.formatDate },
-          { field: 'risk_level', label: 'Risk Level', isSortable: true, tooltip: null },
-          { field: 'monitoring_plan', label: 'Monitoring Plan', isSortable: true, tooltip: null },
-          { field: 'public_health_action', label: 'Latest Public Health Action', isSortable: true, tooltip: null },
-          { field: 'expected_purge_date', label: 'Eligible For Purge After', isSortable: true, tooltip: 'purgeDate', filter: this.formatTimestamp },
-          { field: 'reason_for_closure', label: 'Reason for Closure', isSortable: true, tooltip: null },
-          { field: 'closed_at', label: 'Closed At', isSortable: true, tooltip: null, filter: this.formatTimestamp },
-          { field: 'transferred_at', label: 'Transferred At', isSortable: true, tooltip: null, filter: this.formatTimestamp },
+          { field: 'end_of_monitoring', label: 'End of Monitoring', isSortable: true, tooltip: null, filter: this.formatDate },
           { field: 'latest_report', label: 'Latest Report', isSortable: true, tooltip: null, filter: this.formatTimestamp },
           { field: 'status', label: 'Status', isSortable: true, tooltip: null },
-          { field: 'report_eligibility', label: '', isSortable: false, tooltip: null, filter: this.createEligibilityTooltip, icon: 'far fa-comment' },
+          // { field: 'report_eligibility', label: '', isSortable: false, tooltip: null, filter: this.createEligibilityTooltip, icon: 'far fa-comment' },
         ],
         displayedColData: [],
         rowData: [],
@@ -389,12 +380,12 @@ class PatientsTable extends React.Component {
     return date ? moment(date, 'YYYY-MM-DD').format('MM/DD/YYYY') : '';
   }
 
-  formatEndOfMonitoring(endOfMonitoring) {
-    if (endOfMonitoring === 'Continuous Exposure') {
-      return 'Continuous Exposure';
-    }
-    return moment(endOfMonitoring, 'YYYY-MM-DD').format('MM/DD/YYYY');
-  }
+  // formatEndOfMonitoring(endOfMonitoring) {
+  //   if (endOfMonitoring === 'Continuous Exposure') {
+  //     return 'Continuous Exposure';
+  //   }
+  //   return moment(endOfMonitoring, 'YYYY-MM-DD').format('MM/DD/YYYY');
+  // }
 
   createEligibilityTooltip(reportEligibility, patientId) {
     return <EligibilityTooltip id={patientId} report_eligibility={reportEligibility} inline={false} />;

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -56,7 +56,7 @@ class PatientsTable extends React.Component {
           { field: 'closed_at', label: 'Closed At', isSortable: true, tooltip: null, filter: this.formatTimestamp },
           { field: 'transferred_at', label: 'Transferred At', isSortable: true, tooltip: null, filter: this.formatTimestamp },
           { field: 'latest_report', label: 'Latest Report', isSortable: true, tooltip: null, filter: this.formatTimestamp },
-          { field: 'status', label: 'Status', isSortable: false, tooltip: null },
+          { field: 'status', label: 'Status', isSortable: true, tooltip: null },
           { field: 'report_eligibility', label: '', isSortable: false, tooltip: null, filter: this.createEligibilityTooltip, icon: 'far fa-comment' },
         ],
         displayedColData: [],

--- a/app/javascript/components/subject/CurrentStatus.js
+++ b/app/javascript/components/subject/CurrentStatus.js
@@ -12,9 +12,9 @@ class CurrentStatus extends React.Component {
   generateStatus(status) {
     if (status === 'exposure_symptomatic') {
       return <span className="text-danger">symptomatic</span>;
-    } else if (status === 'exposure_followup') {
+    } else if (status === 'exposure_follow_up') {
       return <span className="text-danger">needs follow up</span>;
-    } else if (status === 'exposure_asymptomatic') {
+    } else if (status === 'exposure_reviewed') {
       return <span className="text-success">reviewed</span>;
     } else if (status === 'exposure_non_reporting') {
       return <span className="text-warning">non-reporting</span>;

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -75,7 +75,7 @@ class ExportJob < ApplicationJob
                             export_type)
         lookups << get_file(user_id,
                             excel_export_dosages(group),
-                            build_filename('Sara-Alert-Full-Export-Dosages', file_index, file_extension),
+                            build_filename(export_app_name + '-Full-Export-Dosages', file_index, file_extension),
                             export_type)
       end
     when 'full_history_purgeable'


### PR DESCRIPTION
# Description
Jira Ticket: SAVAMC2-87 SAVAMC2-120

SAVAMC2-87: On the "All Monitorees" tab, you can now sort by status. This is sorted alphabetically at the moment.
SAVAMC2-120: Public health dashboard now shows updated vaccine headers. End of monitoring updated to be 1 year out of Dose 2. 

Additionally:
* Fixed a bug on editting vaccine dosages. Before the validate function would crash when trying to change values in the edit view due to type issues.

# Testing

NOTE: This assumes that a dosage 2 is administered after a dose 1 and that if you acquire a dose 2, you will not be acquiring another dose 1. This restriction isn't in place yet, because I'm assuming it'll be covered in SAVAMC2-16.

This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
